### PR TITLE
Fix of TypeError due to unintended argument value type

### DIFF
--- a/lib/oneshot_coverage.rb
+++ b/lib/oneshot_coverage.rb
@@ -46,7 +46,7 @@ module OneshotCoverage
         Coverage.result(clear: true, stop: false).
         select { |k, v| is_target?(k, v) }.
         map do |filepath, v|
-          OneshotLog.new(relative_path(filepath), md5_hash_for(filepath), v[:oneshot_lines])
+          OneshotLog.new(relative_path(filepath), md5_hash_for(filepath), v)
         end
 
       if logs.size > 0
@@ -68,7 +68,7 @@ module OneshotCoverage
     end
 
     def is_target?(filepath, value)
-      return false if value[:oneshot_lines].empty?
+      return false if value.empty?
       return false if !filepath.start_with?(@target_path)
       return false if @bundler_path && filepath.start_with?(@bundler_path)
       true


### PR DESCRIPTION
Thank you for creating this gem.
This is a very helpful gem for me thinking about how to introduce `oneshot coverage` into a Rails application.

# Description

Now, when I used this gem, I encountered a problem.
I also created code to fix it.

If this problem is solved, I will send PR because I think that more people will be happy.

It looks like you are using the `[]` method expecting a Hash type for the argument `value` of `def is_target?`.    

Actually, the argument `value` is received as an Array type, so a TypeError occurs.

Example

```
$ value
[nil, 0, nil, nil, 0]
$ value[:oneshot_lines]
TypeError: no implicit conversion of Symbol into Integer
```

See: https://docs.ruby-lang.org/en/master/Coverage.html

# Enviroments

```
ruby -v
ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin17]
```