### PR TITLE
Fix error when empty log file is exist

### DIFF
--- a/lib/oneshot_coverage/logger/file_logger.rb
+++ b/lib/oneshot_coverage/logger/file_logger.rb
@@ -22,7 +22,7 @@ module OneshotCoverage
       private
 
       def fetch
-        JSON.load(File.read(@log_path))
+        JSON.load(File.read(@log_path)) || {}
       rescue Errno::ENOENT
         {}
       end


### PR DESCRIPTION
'nil.fetch' occur when there is an empty log file.

So, returns hash when the file is empty.