### PR TITLE
Provide options for checking bundle_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This gem provides simple tools to use oneshot mode easier. It gives you:
 - Pluggable logger interface
 
 Please notice that it records code executions under the target path(usually, project base path).
-If you have bundle gem path under target path, It will be ignored automatically.
+If you have bundle gem path under target path, It will be ignored by default.
 
 ## Installation
 
@@ -36,6 +36,7 @@ OneshotCoverage.configure(
   target_path: '/base/project/path',
   logger: OneshotCoverage::Logger::NullLogger.new,
   emit_term: nil, # emit per `emit_term` seconds. It tries to emit per request when `nil`.
+  cover_bundle_path: false, # record bundle gem path. Default value is false.
 )
 OneshotCoverage.start
 ```

--- a/lib/oneshot_coverage.rb
+++ b/lib/oneshot_coverage.rb
@@ -30,11 +30,10 @@ module OneshotCoverage
         @next_emit_time = Time.now.to_i + rand(@emit_term)
       end
 
-
       if defined?(Bundler)
         @bundler_path = Bundler.bundle_path.to_s
+        @check_bundle_path = check_bundle_path
       end
-      @check_bundle_path = check_bundle_path
     end
 
     def emit(force_emit)

--- a/lib/oneshot_coverage.rb
+++ b/lib/oneshot_coverage.rb
@@ -22,7 +22,7 @@ module OneshotCoverage
   OneshotLog = Struct.new(:path, :md5_hash, :lines)
 
   class Reporter
-    def initialize(target_path:, logger:, emit_term: nil, check_bundle_path:)
+    def initialize(target_path:, logger:, emit_term: nil, check_bundle_path: false)
       @target_path = target_path
       @logger = logger
       @emit_term = emit_term

--- a/lib/oneshot_coverage.rb
+++ b/lib/oneshot_coverage.rb
@@ -22,7 +22,7 @@ module OneshotCoverage
   OneshotLog = Struct.new(:path, :md5_hash, :lines)
 
   class Reporter
-    def initialize(target_path:, logger:, emit_term: nil, check_bundle_path: false)
+    def initialize(target_path:, logger:, emit_term: nil, cover_bundle_path: false)
       @target_path = target_path
       @logger = logger
       @emit_term = emit_term
@@ -32,7 +32,7 @@ module OneshotCoverage
 
       if defined?(Bundler)
         @bundler_path = Bundler.bundle_path.to_s
-        @check_bundle_path = check_bundle_path
+        @cover_bundle_path = cover_bundle_path
       end
     end
 
@@ -70,7 +70,7 @@ module OneshotCoverage
 
     def is_target?(filepath, value)
       return false if value[:oneshot_lines].empty?
-      return @check_bundle_path if @bundler_path && filepath.start_with?(@bundler_path)
+      return @cover_bundle_path if @bundler_path && filepath.start_with?(@bundler_path)
       return false if !filepath.start_with?(@target_path)
       true
     end
@@ -111,12 +111,12 @@ module OneshotCoverage
     @reporter&.emit(force_emit)
   end
 
-  def configure(target_path:, logger: OneshotCoverage::Logger::NullLogger.new, emit_term: nil, check_bundle_path: false)
+  def configure(target_path:, logger: OneshotCoverage::Logger::NullLogger.new, emit_term: nil, cover_bundle_path: false)
     @reporter = OneshotCoverage::Reporter.new(
       target_path: Pathname.new(target_path).cleanpath.to_s + "/",
       logger: logger,
       emit_term: emit_term,
-      check_bundle_path: check_bundle_path
+      cover_bundle_path: cover_bundle_path
     )
   end
 end

--- a/lib/oneshot_coverage.rb
+++ b/lib/oneshot_coverage.rb
@@ -22,7 +22,7 @@ module OneshotCoverage
   OneshotLog = Struct.new(:path, :md5_hash, :lines)
 
   class Reporter
-    def initialize(target_path:, logger:, emit_term: nil)
+    def initialize(target_path:, logger:, emit_term: nil, check_bundle_path:)
       @target_path = target_path
       @logger = logger
       @emit_term = emit_term
@@ -30,9 +30,11 @@ module OneshotCoverage
         @next_emit_time = Time.now.to_i + rand(@emit_term)
       end
 
+
       if defined?(Bundler)
         @bundler_path = Bundler.bundle_path.to_s
       end
+      @check_bundle_path = check_bundle_path
     end
 
     def emit(force_emit)
@@ -69,13 +71,17 @@ module OneshotCoverage
 
     def is_target?(filepath, value)
       return false if value[:oneshot_lines].empty?
+      return @check_bundle_path if @bundler_path && filepath.start_with?(@bundler_path)
       return false if !filepath.start_with?(@target_path)
-      return false if @bundler_path && filepath.start_with?(@bundler_path)
       true
     end
 
     def relative_path(filepath)
-      filepath[@target_path.size..-1]
+      if filepath.include?(@target_path)
+        filepath[@target_path.size..-1]
+      else
+        filepath
+      end
     end
 
     def md5_hash_cache
@@ -106,17 +112,12 @@ module OneshotCoverage
     @reporter&.emit(force_emit)
   end
 
-  def configure(target_path:, logger: OneshotCoverage::Logger::NullLogger.new, emit_term: nil)
-    target_path_by_pathname =
-      if target_path.is_a? Pathname
-        target_path
-      else
-        Pathname.new(target_path)
-      end
+  def configure(target_path:, logger: OneshotCoverage::Logger::NullLogger.new, emit_term: nil, check_bundle_path: false)
     @reporter = OneshotCoverage::Reporter.new(
-      target_path: target_path_by_pathname.cleanpath.to_s + "/",
+      target_path: Pathname.new(target_path).cleanpath.to_s + "/",
       logger: logger,
       emit_term: emit_term,
+      check_bundle_path: check_bundle_path
     )
   end
 end


### PR DESCRIPTION
Issue: https://github.com/riseshia/oneshot_coverage/issues/6

* If `check_bundle_path:` is `true`, oneshot_coverage reports files including bundle_path
* Default value for `check_bundle_path:` is `false`
  - this matches with existing design of oneshot_coverage