### PR TITLE
Fix: SimpleCov file generation logic

### DIFF
--- a/lib/oneshot_coverage/simplecov_reporter.rb
+++ b/lib/oneshot_coverage/simplecov_reporter.rb
@@ -69,7 +69,7 @@ module OneshotCoverage
     def fill_lines(coverages)
       oneshot_coverage_logs.each do |filepath, linenums|
         linenums.each do |linenum|
-          coverages[filepath][linenum - 1] = 1
+          coverages[filepath][linenum - 1] = 1 unless coverages[filepath].nil?
         end
       end
     end


### PR DESCRIPTION
One day I tried to create a SimpleCov HTML file using a JSON file generated by oneshot_coverage, but getting has an error.
I fixed that error and It seems to work fine.
I also ran oneshot_coverage including my fix in a large Rails project.  It worked and showed a corrective coverage HTML.


The steps to generate the error are as follows.

Step.1 Test and generate target_app/coverage.json

```
> bundle exec rake test 
```

Step. 2 Generate SimpleCov report

```
> ruby gen_simplecov_report.rb
/oneshot_coverage/lib/oneshot_coverage/simplecov_reporter.rb:72:in `block (2 levels) in fill_lines': undefined method `[]=' for nil:NilClass (NoMethodError)
	from /oneshot_coverage/lib/oneshot_coverage/simplecov_reporter.rb:71:in `each'
	from /oneshot_coverage/lib/oneshot_coverage/simplecov_reporter.rb:71:in `block in fill_lines'
	from /oneshot_coverage/lib/oneshot_coverage/simplecov_reporter.rb:70:in `each'
	from /oneshot_coverage/lib/oneshot_coverage/simplecov_reporter.rb:70:in `fill_lines'
	from /oneshot_coverage/lib/oneshot_coverage/simplecov_reporter.rb:36:in `run'
```


