### PR TITLE
chore: specify required ruby version

### DIFF
--- a/oneshot_coverage.gemspec
+++ b/oneshot_coverage.gemspec
@@ -34,6 +34,5 @@ Gem::Specification.new do |spec|
   # spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Release ruby version lock temperary
-  # spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.6'
 end


### PR DESCRIPTION
I don't know why this spec was commented out in gemspec.
Ruby's Coverage one-shot mode is available only on Ruby 2.6.0 or later.

This pull request sets the required version of Ruby to 2.6.0 or later.